### PR TITLE
Add comment line correction feature

### DIFF
--- a/pr-inspection-assistant/src/.env.local.example
+++ b/pr-inspection-assistant/src/.env.local.example
@@ -22,6 +22,9 @@ System_TeamProjectId=56107797-a166-4245-aa2a-1921c5139897
 Build_Repository_Name=StudentWeb
 # Set to the Pull Request ID to review
 System_PullRequest_PullRequestId=86649
+# OpenAI struggles with determining the code line number and offset to which the suggestion applies. 
+# Setting this to true will use our own algorithm to determine the line number and offset.
+Comment_Line_Correction=true
 
 #--- Code Review Options ---
 # Set to true to review for bugs

--- a/pr-inspection-assistant/src/commentLineNumberAndOffsetFixer.ts
+++ b/pr-inspection-assistant/src/commentLineNumberAndOffsetFixer.ts
@@ -1,0 +1,220 @@
+import parseGitDiff, { AddedLine, AnyChunk, AnyLineChange, DeletedLine, GitDiff, UnchangedLine } from 'parse-git-diff';
+
+/**
+ * The `CommentLineNumberAndOffsetFixer` class provides methods to adjust the line numbers and offsets of comments
+ * in a review based on a provided git diff. This is useful for ensuring that comments remain correctly positioned
+ * after changes have been made to the code.
+ */
+export class CommentLineNumberAndOffsetFixer {
+    /**
+     * Fixes the line numbers and offsets of comments in a review based on the provided git diff.
+     * @param review - The review object containing threads with comments.
+     * @param diff - The git diff string used to adjust the line numbers and offsets.
+     */
+    public fix(review: any, diff: string): void {
+        if (!review.threads.length) {
+            console.info('No threads found in the review. No line numbers to fix.');
+            return;
+        }
+
+        console.info(`Fixing comment line numbers for review with ${review.threads.length} threads. Diff content:`, diff);
+        const parsedDiff = parseGitDiff(diff);
+
+        for (const thread of review.threads) {
+            if (thread.threadContext) {
+                console.info(`Thread before: ${JSON.stringify(thread, null, 4)}`);
+                this.fixThreadContextLineNumberAndOffsets(thread.threadContext, parsedDiff, true);
+                this.fixThreadContextLineNumberAndOffsets(thread.threadContext, parsedDiff, false);
+                console.info(`Thread after:`, JSON.stringify(thread, null, 4));
+            }
+        }
+    }
+
+    /**
+     * Fixes the line numbers and offsets in the thread context based on the parsed diff.
+     *
+     * @param threadContext - The context of the thread containing line numbers and offsets.
+     * @param parsedDiff - The parsed Git diff containing changes.
+     * @param isRightSide - A boolean indicating whether the changes are on the right side of the diff.
+     * @returns void
+     */
+    private fixThreadContextLineNumberAndOffsets(threadContext: any, parsedDiff: GitDiff, isRightSide: boolean): void {
+        const fileStart = isRightSide ? threadContext.rightFileStart : threadContext.leftFileStart;
+        const fileEnd = isRightSide ? threadContext.rightFileEnd : threadContext.leftFileEnd;
+    
+        if (fileStart?.snippet?.length) {
+            this.updateFileStartAndEnd(fileStart, fileEnd, parsedDiff, isRightSide);
+        }
+    }
+
+    /**
+     * Updates the start and end line numbers and offsets for a file based on the provided git diff.
+     * @param fileStart - The start context of the file.
+     * @param fileEnd - The end context of the file.
+     * @param parsedDiff - The parsed git diff object.
+     * @param isRightSide - A boolean indicating if the changes are on the right side of the diff.
+     */
+    private updateFileStartAndEnd(fileStart: any, fileEnd: any, parsedDiff: GitDiff, isRightSide: boolean): void {
+        const snippets = fileStart.snippet.split('\n');
+        const isMultilineSnippet = snippets.length > 1;
+        console.info('isMultilineSnippet', isMultilineSnippet);
+        const snippetFirst = snippets[0];
+        
+        const { lineNumber, offset } = this.getLineNumberAndOffset(parsedDiff, snippetFirst, fileStart.line, isRightSide);
+        if (lineNumber === undefined || offset === undefined) {
+            console.warn('No line number or offset found for snippet:', snippetFirst, 'line:');
+            return;
+        }
+
+        fileStart.line = lineNumber;
+        fileStart.offset = offset;
+        fileEnd.line = lineNumber;
+        fileEnd.offset = offset + snippetFirst.length;
+
+        if (isMultilineSnippet) {
+            this.updateFileEndForMultilineSnippet(fileEnd, snippets, parsedDiff, isRightSide);
+        }
+    }
+
+    /**
+     * Updates the `fileEnd` object to reflect the end position of a multiline snippet.
+     *
+     * @param fileEnd - The object representing the end of the file, which will be updated with the new line number and offset.
+     * @param snippets - An array of strings representing the snippets of code.
+     * @param parsedDiff - The parsed Git diff object containing information about the changes.
+     * @param isRightSide - A boolean indicating whether the changes are on the right side of the diff.
+     */
+    private updateFileEndForMultilineSnippet(fileEnd: any, snippets: string[], parsedDiff: GitDiff, isRightSide: boolean): void {
+        const snippetLast = snippets[snippets.length - 1];
+        const { lineNumber: lastLineNumber, offset: lastLineOffset } = this.getLineNumberAndOffset(parsedDiff, snippetLast, fileEnd.line, isRightSide);
+        if (lastLineNumber === undefined || lastLineOffset === undefined) {
+            console.warn('No line number or offset found for last line of snippet:', snippetLast);
+            return;
+        }
+        fileEnd.line = lastLineNumber;
+        fileEnd.offset = lastLineOffset + snippetLast.length;
+    }
+
+    /**
+     * Retrieves the line number and offset of a specified text within a parsed Git diff.
+     *
+     * @param parsedDiff - The parsed Git diff object.
+     * @param searchText - The text to search for within the diff.
+     * @param originalLineNumber - The original line number to start the search from.
+     * @param shouldSearchRightSide - A boolean indicating whether to search on the right side of the diff. Defaults to true.
+     * @returns An object containing the line number and offset of the searchText within the diff. If the text is not found, both values will be undefined.
+     */
+    private getLineNumberAndOffset(parsedDiff: GitDiff, searchText: string, originalLineNumber: number, shouldSearchRightSide: boolean = true): { lineNumber: number | undefined, offset: number | undefined } {
+        const line = this.getGitDiffLine(parsedDiff, searchText, originalLineNumber, shouldSearchRightSide);
+        if (!line) {
+            return { lineNumber: undefined, offset: undefined };
+        }
+        const lineNumber = this.getLineNumber(line, shouldSearchRightSide);
+        const offset = line.content.indexOf(searchText) + 1;
+        return { lineNumber, offset };
+    }
+
+    /**
+     * Retrieves the line number from the given diff line metadata.
+     *
+     * @param diffLineMeta - The metadata of the line change.
+     * @param isRightSide - A boolean indicating whether to retrieve the line number from the right side (after the change) or the left side (before the change).
+     * @returns The line number from the specified side, or undefined if not applicable.
+     */
+    private getLineNumber(diffLineMeta: AnyLineChange, isRightSide: boolean): number | undefined {
+        return isRightSide 
+            ? (diffLineMeta as AddedLine | UnchangedLine)?.lineAfter 
+            : (diffLineMeta as DeletedLine | UnchangedLine)?.lineBefore;
+    }
+
+    /**
+     * Retrieves the closest line number from a Git diff that matches the specified search text.
+     *
+     * @param diff - The Git diff object containing the changes.
+     * @param searchText - The text to search for within the diff.
+     * @param originalLineNumber - The original line number to find the closest match for.
+     * @param shouldSearchRightSide - Optional. Indicates whether to search the right side of the diff. Defaults to true.
+     * @returns The closest line number that matches the search text, or undefined if no match is found.
+     */
+    private getGitDiffLine(diff: GitDiff, searchText: string, originalLineNumber: number, shouldSearchRightSide: boolean = true) {
+        const changes = this.getChangesFromDiff(diff);
+        const lines = this.filterChanges(changes, searchText, shouldSearchRightSide);
+        const line = this.findClosestLine(lines, originalLineNumber, shouldSearchRightSide);
+
+        if (!line) {
+            this.logWarnings(searchText, originalLineNumber, shouldSearchRightSide, changes, lines, diff);
+        }
+
+        console.info('getGitDiffLine:', line);
+
+        return line;
+    }
+
+    /**
+     * Extracts and returns an array of line changes from the given Git diff.
+     *
+     * @param diff - The Git diff object containing file changes.
+     * @returns An array of line changes extracted from the diff.
+     */
+    private getChangesFromDiff(diff: GitDiff): AnyLineChange[] {
+        if (!diff.files.length) {
+            console.warn('No files found in the diff.');
+            return [];
+        }
+        return diff.files[0].chunks.flatMap((chunk) => 'changes' in chunk ? chunk.changes : []);
+    }
+
+    /**
+     * Filters an array of line changes based on the provided search text and side of the changes.
+     *
+     * @param changes - An array of line changes to filter.
+     * @param searchText - The text to search for within the line changes.
+     * @param shouldSearchRightSide - A boolean indicating whether to search the right side (added lines) or the left side (deleted lines).
+     * @returns An array of line changes that match the search criteria.
+     */
+    private filterChanges(changes: AnyLineChange[], searchText: string, shouldSearchRightSide: boolean): AnyLineChange[] {
+        return changes.filter((change: AnyLineChange) => 
+            change.content.includes(searchText) && 
+            (change.type === 'UnchangedLine' || change.type === (shouldSearchRightSide ? 'AddedLine' : 'DeletedLine'))
+        );
+    }
+
+    /**
+     * Finds the closest line to the given original line number from a list of line changes.
+     *
+     * @param lines - An array of line changes to search through.
+     * @param originalLineNumber - The original line number to find the closest line to.
+     * @param shouldSearchRightSide - A boolean indicating whether to search the right side (true) or the left side (false).
+     * @returns The closest line change to the original line number, or undefined if the list is empty.
+     */
+    private findClosestLine(lines: AnyLineChange[], originalLineNumber: number, shouldSearchRightSide: boolean): AnyLineChange | undefined {
+        return lines.reduce((previous: AnyLineChange, current: AnyLineChange) => {
+            if (shouldSearchRightSide) {
+                const currentLine = current as AddedLine | UnchangedLine;
+                const previousLine = previous as AddedLine | UnchangedLine;
+                return Math.abs(currentLine.lineAfter - originalLineNumber) < Math.abs(previousLine.lineAfter - originalLineNumber) ? currentLine : previousLine;
+            } else {
+                const currentLine = current as DeletedLine | UnchangedLine;
+                const previousLine = previous as DeletedLine | UnchangedLine;
+                return Math.abs(currentLine.lineBefore - originalLineNumber) < Math.abs(previousLine.lineBefore - originalLineNumber) ? currentLine : previousLine;
+            }
+        }, lines[0]);
+    }
+
+    /**
+     * Logs warnings when no line is found for the given search text.
+     *
+     * @param searchText - The text to search for in the diff.
+     * @param originalLineNumber - The original line number where the search text was expected.
+     * @param shouldSearchRightSide - A flag indicating whether to search the right side of the diff.
+     * @param changes - An array of changes that were applied.
+     * @param lines - An array of all line changes.
+     * @param diff - The Git diff object containing the changes.
+     */
+    private logWarnings(searchText: string, originalLineNumber: number, shouldSearchRightSide: boolean, changes: AnyLineChange[], lines: AnyLineChange[], diff: GitDiff): void {
+        console.warn('getGitDiffLine: No line found for searchText:', searchText, 'originalLineNumber:', originalLineNumber, 'shouldSearchRightSide:', shouldSearchRightSide);
+        console.warn('changes', JSON.stringify(changes, null, 4));
+        console.warn('lines', JSON.stringify(lines, null, 4));
+        console.warn('diff', JSON.stringify(diff, null, 4));
+    }
+}

--- a/pr-inspection-assistant/src/main.ts
+++ b/pr-inspection-assistant/src/main.ts
@@ -3,6 +3,7 @@ import { OpenAI, AzureOpenAI } from "openai";
 import { ChatGPT } from './chatgpt';
 import { Repository } from './repository';
 import { PullRequest } from './pullrequest';
+import parseGitDiff, { AddedLine, AnyChunk, AnyLineChange, Chunk, DeletedLine, GitDiff, UnchangedLine } from 'parse-git-diff';
 
 export class Main {
     private static _chatGpt: ChatGPT;
@@ -32,6 +33,7 @@ export class Main {
         const performance = tl.getBoolInput('performance', false);
         const bestPractices = tl.getBoolInput('best_practices', false);
         const modifiedLinesOnly = tl.getBoolInput('modified_lines_only', false);
+        const enableCommentLineCorrection = tl.getBoolInput('comment_line_correction', false);
 
         console.info(`file_extensions: ${fileExtensions}`);
         console.info(`file_excludes: ${filesToExclude}`);
@@ -42,12 +44,13 @@ export class Main {
         console.info(`modified_lines_only: ${modifiedLinesOnly}`);
         console.info(`azureApiEndpoint: ${azureApiEndpoint}`);
         console.info(`azureModelDeployment: ${azureModelDeployment}`);
+        console.info(`enableCommentLineCorrection: ${enableCommentLineCorrection}`);
         
         const client = azureApiEndpoint ? new AzureOpenAI({ apiKey: apiKey, endpoint: azureApiEndpoint, apiVersion: azureApiVersion, deployment: azureModelDeployment }) : new OpenAI({ apiKey: apiKey });
 
         // const client = new AzureOpenAI({ apiKey: apiKey, endpoint: azureApiEndpoint, baseURL: `${azureApiEndpoint}/openai/`, apiVersion: azureApiVersion, deployment: azureModelDeployment });
         
-        this._chatGpt = new ChatGPT(client, bugs, performance, bestPractices, modifiedLinesOnly, additionalPrompts);
+        this._chatGpt = new ChatGPT(client, bugs, performance, bestPractices, modifiedLinesOnly, enableCommentLineCorrection, additionalPrompts);
         this._repository = new Repository();
         this._pullRequest = new PullRequest();
 

--- a/pr-inspection-assistant/src/package-lock.json
+++ b/pr-inspection-assistant/src/package-lock.json
@@ -15,6 +15,7 @@
         "azure-pipelines-task-lib": "^4.7.0",
         "gpt-tokenizer": "^2.1.2",
         "openai": "^4.80.0",
+        "parse-git-diff": "^0.0.17",
         "simple-git": "^3.21.0"
       },
       "devDependencies": {
@@ -2868,6 +2869,11 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
       "dev": true
+    },
+    "node_modules/parse-git-diff": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/parse-git-diff/-/parse-git-diff-0.0.17.tgz",
+      "integrity": "sha512-Y9oguTLoWJOeGwOeaFP1SxaSIaIp3VtEm7NHHg8Dagaa4fQt2MwFHxdQBLk0LPseuFTgxOs9T+O+uS8Oe5oqEw=="
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",

--- a/pr-inspection-assistant/src/package.json
+++ b/pr-inspection-assistant/src/package.json
@@ -19,6 +19,7 @@
     "azure-pipelines-task-lib": "^4.7.0",
     "gpt-tokenizer": "^2.1.2",
     "openai": "^4.80.0",
+    "parse-git-diff": "^0.0.17",
     "simple-git": "^3.21.0"
   },
   "devDependencies": {

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 10
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [
@@ -109,6 +109,13 @@
             "label": "Verbose Logging",
             "defaultValue": false,
             "helpMarkDown": "Specify to show additional debug logging. Default value is `false`."
+        },
+        {
+            "name": "comment_line_correction",
+            "type": "boolean",
+            "label": "Enable comment line correction",
+            "defaultValue": true,
+            "helpMarkDown": "Correct comment line number and offsets."
         }
     ],
     "execution": {

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.5",
+    "version": "2.1.10",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
This PR aims to address an issue w/ OpenAI having trouble reporting the line and offset number to which it's commenting on.

This feature is on by default but can be disabled via the task option: **comment_line_correction**.