### PR TITLE
Update default OpenAI model to 'o3-mini' and increment version to 2.1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 - A generated API key for you OpenAI service
 - Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
 - A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
-  - By default the task will try to use a deployment called `'o1-mini'`
+  - By default the task will try to use a deployment called `'o3-mini'`
   - Valid options are:
+    - '03-mini'
     - 'o1-mini'
     - 'o1-preview'
     - 'gpt-4o'

--- a/pr-inspection-assistant/assets/overview.md
+++ b/pr-inspection-assistant/assets/overview.md
@@ -32,8 +32,9 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 - A generated API key for you OpenAI service
 - Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
 - A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
-  - By default the task will try to use a deployment called `'o1-mini'`
+  - By default the task will try to use a deployment called `'o3-mini'`
   - Valid options are:
+    - 'o3-mini'
     - 'o1-mini'
     - 'o1-preview'
     - 'gpt-4o'

--- a/pr-inspection-assistant/src/.env.local.example
+++ b/pr-inspection-assistant/src/.env.local.example
@@ -6,7 +6,7 @@ Build_Reason=PullRequest
 # OpenAI API Key
 Api_Key=<your_api_key>
 # OpenAI Model to use for code review
-Ai_Model=o1-mini
+Ai_Model=o3-mini
 
 # Azure DevOps Bearer Token.  Used to authenticate to Azure DevOps API
 System_AccessToken=<your_access_token>

--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -90,6 +90,7 @@ export class ChatGPT {
             fileName = `/${fileName}`;
         }
         let model = tl.getInput('ai_model', true) as | (string & {})
+            | 'o3-mini'
             | 'o1-mini'
             | 'o1-preview'
             | 'gpt-4o'

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 12
+        "Patch": 13
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [
@@ -41,8 +41,9 @@
             "name": "ai_model",
             "type": "pickList",
             "label": "OpenAI API Model",
-            "defaultValue": "o1-mini",
+            "defaultValue": "o3-mini",
             "options": {
+                "o3-mini": "o3-mini",
                 "o1-mini": "o1-mini",
                 "o1-preview": "o1-preview",
                 "gpt-4o": "gpt-4o",

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.12",
+    "version": "2.1.13",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
Changed default model to 03-mini to address issue where PRIA would comment on unchanged lines.