### PR TITLE
Fixed issue related to wrong file diff generation resulting in incorrect comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,43 +4,44 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 
 ## Key Features
 
-- **Automated PR Reviews**: Leverage OpenAI to analyze code changes in pull requests.
-- **Supports Azure OpenAI**: Isolate your reviews using your own internal model deployments in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio).
-- **Code Quality Suggestions**: Detect potential issues and ensure best practices are followed.
-- **Customizable Review Criteria**: Tailor the bot to specific code quality metrics.
-- **Azure DevOps Integration**: Seamlessly integrates with existing DevOps pipelines.
-- **Natural Language Feedback**: Provides human-readable, actionable feedback.
+-   **Automated PR Reviews**: Leverage OpenAI to analyze code changes in pull requests.
+-   **Supports Azure OpenAI**: Isolate your reviews using your own internal model deployments in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio).
+-   **Code Quality Suggestions**: Detect potential issues and ensure best practices are followed.
+-   **Customizable Review Criteria**: Tailor the bot to specific code quality metrics.
+-   **Azure DevOps Integration**: Seamlessly integrates with existing DevOps pipelines.
+-   **Natural Language Feedback**: Provides human-readable, actionable feedback.
 
 ![](./pr-inspection-assistant/assets/ado-ai-comment.jpg)
 
 ## Use Cases
 
-- **Automate Routine PR Tasks**: Speed up the code review process by automating common review tasks.
-- **Improve Code Quality**: Receive consistent, detailed feedback to enhance code quality.
-- **Early Bug Detection**: Help developers understand best practices and identify bugs early in the development cycle.
+-   **Automate Routine PR Tasks**: Speed up the code review process by automating common review tasks.
+-   **Improve Code Quality**: Receive consistent, detailed feedback to enhance code quality.
+-   **Early Bug Detection**: Help developers understand best practices and identify bugs early in the development cycle.
 
 ## Process
+
 ![](./pr-inspection-assistant/assets/flowchart.jpg)
 
 ## Prerequisites
 
-- An [OpenAI API Key](https://platform.openai.com/docs/overview)
-- Build Administrators must be given "Contribute to pull requests" access. Check [this Stack Overflow answer](https://stackoverflow.com/a/57985733) for guidance on setting up permissions.
+-   An [OpenAI API Key](https://platform.openai.com/docs/overview)
+-   Build Administrators must be given "Contribute to pull requests" access. Check [this Stack Overflow answer](https://stackoverflow.com/a/57985733) for guidance on setting up permissions.
 
 ### If Using Azure OpenAI
 
-- A generated API key for you OpenAI service
-- Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
-- A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
-  - By default the task will try to use a deployment called `'o3-mini'`
-  - Valid options are:
-    - 'o3-mini'
-    - 'o1-mini'
-    - 'o1-preview'
-    - 'gpt-4o'
-    - 'gpt-4'
-    - 'gpt-3.5-turbo'
-- A designated [API version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation). Defaults to `'2024-10-21'`
+-   A generated API key for you OpenAI service
+-   Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
+-   A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
+    -   By default the task will try to use a deployment called `'o3-mini'`
+    -   Valid options are:
+        -   'o3-mini'
+        -   'o1-mini'
+        -   'o1-preview'
+        -   'gpt-4o'
+        -   'gpt-4'
+        -   'gpt-3.5-turbo'
+-   A designated [API version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation). Defaults to `'2024-10-21'`
 
 [Learn more about Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio)
 
@@ -48,11 +49,11 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 
 ### 1. Install the PRIA DevOps Extension
 
-   Install the [PRIA](https://marketplace.visualstudio.com/items?itemName=EricWellnitz.pria) DevOps extension from the Azure DevOps Marketplace.
+Install the [PRIA](https://marketplace.visualstudio.com/items?itemName=EricWellnitz.pria) DevOps extension from the Azure DevOps Marketplace.
 
 ### 2. Create a PRIA Code Review Pipeline
 
-   Create an [Azure DevOps Pipeline](https://learn.microsoft.com/en-us/azure/devops/pipelines/create-first-pipeline) using the following YAML snippet to set up the PRIA code review task:
+Create an [Azure DevOps Pipeline](https://learn.microsoft.com/en-us/azure/devops/pipelines/create-first-pipeline) using the following YAML snippet to set up the PRIA code review task:
 
 #### OpenAI API
 
@@ -60,15 +61,15 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 trigger: none
 
 jobs:
-  - job: CodeReview
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-        persistCredentials: true
-      - task: PRIA@2
-        inputs:
-          api_key: '$(OpenAI_ApiKey)'
+    - job: CodeReview
+      pool:
+          vmImage: 'ubuntu-latest'
+      steps:
+          - checkout: self
+            persistCredentials: true
+          - task: PRIA@2
+            inputs:
+                api_key: '$(OpenAI_ApiKey)'
 ```
 
 #### Azure OpenAI
@@ -77,44 +78,46 @@ jobs:
 trigger: none
 
 jobs:
-  - job: CodeReview
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-        persistCredentials: true
-      - task: PRIA@2
-        inputs:
-          api_key: '$(OpenAI_ApiKey)'
-          api_version: '2024-10-21'
-          api_endpoint: 'https://my-foundry-project.openai.azure.com/'
-          ai_model: 'gpt-4o'
+    - job: CodeReview
+      pool:
+          vmImage: 'ubuntu-latest'
+      steps:
+          - checkout: self
+            persistCredentials: true
+          - task: PRIA@2
+            inputs:
+                api_key: '$(OpenAI_ApiKey)'
+                api_version: '2024-10-21'
+                api_endpoint: 'https://my-foundry-project.openai.azure.com/'
+                ai_model: 'gpt-4o'
 ```
+
 ### 3. Optional Task Inputs
 
 Additional input options can be set to tailor how the code is reviewed.
 
-| Input | Type | Default | Description |
-|---|---|---|---|
-| `bugs` | Boolean | `false` | Specify whether to enable bug checking during the code review process. |
-| `performance` | Boolean | `false` | Specify whether to include performance checks during the code review process. |
-| `best_practices` | Boolean | `false` | Specify whether to include checks for missed best practices during the code review process. |
-| `modified_lines_only` | Boolean | `true` | Specify whether to check modified lines only. |
-| `file_extensions` | String | `null` | Specify a comma-separated list of file extensions for which you want to perform a code review. |
-| `file_excludes` | String | `null` | Specify a comma-separated list of file names that should be excluded from code reviews. |
-| `additional_prompts` | String | `null` | Specify additional OpenAI prompts as a comma-separated list to enhance the code review. |
+| Input                 | Type    | Default | Description                                                                                    |
+| --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `bugs`                | Boolean | `false` | Specify whether to enable bug checking during the code review process.                         |
+| `performance`         | Boolean | `false` | Specify whether to include performance checks during the code review process.                  |
+| `best_practices`      | Boolean | `false` | Specify whether to include checks for missed best practices during the code review process.    |
+| `modified_lines_only` | Boolean | `true`  | Specify whether to check modified lines only.                                                  |
+| `file_extensions`     | String  | `null`  | Specify a comma-separated list of file extensions for which you want to perform a code review. |
+| `file_excludes`       | String  | `null`  | Specify a comma-separated list of file names that should be excluded from code reviews.        |
+| `additional_prompts`  | String  | `null`  | Specify additional OpenAI prompts as a comma-separated list to enhance the code review.        |
 
 ### 4. Configure your Main Branch for Build Validation
 
-  Note that `pr` triggers do not work in Azure repos.
-  
-  Cofigure Azure DevOps [branch policies](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation) to use the PRIA Code Review Pipeline created above as a build validation pipeline.
+Note that `pr` triggers do not work in Azure repos.
 
+Cofigure Azure DevOps [branch policies](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation) to use the PRIA Code Review Pipeline created above as a build validation pipeline.
 
 ## Build & Publish
 
 1. Install [Prequisites](https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops#prerequisites)
-1. Install dependencies and build extension
+
+2. Install dependencies and build extension
+
 ```bash
 # Navigate to src and install
 $ cd pr-inspection-assistant/src
@@ -125,10 +128,12 @@ $ npm run package
 ```
 
 ## Local Development Testing
-This is a work in progress.  
+
+This is a work in progress.
 
 1. Copy `.env.local.example` to `.env.local` and fill in the values
 2. On your target git repo for review (specified by `System_DefaultWorkingDirectory` in `.env.local`), set your current branch to the desired pull request in Azure Devops.
+
 ```bash
 # Fetch the refspec for the pull requests
 git fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/pull/<your_pr_id>/merge:refs/remotes/pull/<your_pr_id>/merge
@@ -136,20 +141,22 @@ git fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules
 # Set current branch to PR branch
 git checkout pull/<your_pr_id>/merge
 ```
+
 3. Compare file diffs to make sure it's the same as what is reported in Azure Devops for the PR
+
 ```bash
 git diff --name-only origin/master
 ```
 
-If the files are different, you may need to run the Azure Devops Pipeline for the Pull Request so that its PR branch is up-to-date w/ latest master/main branch.  Then re-run step 2 and 3.
+If the files are different, you may need to run the Azure Devops Pipeline for the Pull Request so that its PR branch is up-to-date w/ latest master/main branch. Then re-run step 2 and 3.
 
-4. After determining file diff matches Azure Devops PR, in `.env.local`, set `TargetBranch_IncludeOriginPrefix` to false.  This is so that the file diffs won't change on us (because our target branch will be our local master) while we're testing, which could be caused by new pushes to origin/master.
+4. Run the task locally
 
-5. Run the task locally
 ```bash
 npm run dev
 ```
 
 ### Resources
-- [Marketplace Pipeline Extension](https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops)
-- [Publisher Portal](https://marketplace.visualstudio.com/manage/publishers)
+
+-   [Marketplace Pipeline Extension](https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops)
+-   [Publisher Portal](https://marketplace.visualstudio.com/manage/publishers)

--- a/pr-inspection-assistant/src/.env.local.example
+++ b/pr-inspection-assistant/src/.env.local.example
@@ -12,6 +12,8 @@ Ai_Model=o3-mini
 System_AccessToken=<your_access_token>
 # Set to the root of your local git repo to be reviewed
 System_DefaultWorkingDirectory=C:/dev/StudentWeb
+# Set to the source branch to be reviewed against.  This should match your PR source branch.
+System_PullRequest_SourceBranch=<your_source_branch>
 # Set to the target branch name to be reviewed against.  Typically, this is master.
 System_PullRequest_TargetBranchName=master
 # Set to the URL of your Azure DevOps instance
@@ -25,6 +27,9 @@ System_PullRequest_PullRequestId=86649
 # OpenAI struggles with determining the code line number and offset to which the suggestion applies. 
 # Setting this to true will use our own algorithm to determine the line number and offset.
 Comment_Line_Correction=true
+# Set to true to allow requeues.  This will allow PRIA to review requeued PRs.
+Allow_Requeue=false
+
 
 #--- Code Review Options ---
 # Set to true to review for bugs
@@ -40,8 +45,6 @@ Modified_Lines_Only=true
 # Set to true to allow local dev testing of PRIA. 
 # Setting to false will cause PRIA to run same as if it were in a PR build and will also invalidate the rest of the env vars in this file.
 Dev_Mode=true
-# Set to true if you want to include origin/ in the target branch name.  This will cause the diffs to be different if origin/master changes.
-TargetBranch_IncludeOriginPrefix=false
 # Experimental.  This is used to automatically set up the current branch to the PR branch.
 Auto_Setup_PR_Branch=false
 # Set to true to enable verbose logging

--- a/pr-inspection-assistant/src/main.ts
+++ b/pr-inspection-assistant/src/main.ts
@@ -37,6 +37,7 @@ export class Main {
         const bestPractices = tl.getBoolInput('best_practices', false);
         const modifiedLinesOnly = tl.getBoolInput('modified_lines_only', false);
         const enableCommentLineCorrection = tl.getBoolInput('comment_line_correction', false);
+        const allowRequeue = tl.getBoolInput('allow_requeue', false);
 
         console.info(`file_extensions: ${fileExtensions}`);
         console.info(`file_extension_excludes: ${fileExtensionExcludes}`);
@@ -49,6 +50,7 @@ export class Main {
         console.info(`azureApiEndpoint: ${azureApiEndpoint}`);
         console.info(`azureModelDeployment: ${azureModelDeployment}`);
         console.info(`enableCommentLineCorrection: ${enableCommentLineCorrection}`);
+        console.info(`allowRequeue: ${allowRequeue}`);
 
         const client = azureApiEndpoint
             ? new AzureOpenAI({
@@ -79,7 +81,7 @@ export class Main {
         const lastMergedCommit = await this._pullRequest.GetLastMergeSourceCommitHash();
         const isRequeued = lastReviewedCommit === lastMergedCommit;
 
-        if (isRequeued) {
+        if (isRequeued && !allowRequeue) {
             // Prevents PRIA from reviewing again based on last reviewed commit
             console.info(`Aborting.  Last reviewed commit matches last merged commit: ${lastReviewedCommit}.`);
             return;

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 17
+        "Patch": 22
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [
@@ -125,6 +125,13 @@
             "label": "Enable comment line correction",
             "defaultValue": true,
             "helpMarkDown": "Correct comment line number and offsets."
+        },
+        {
+            "name": "allow_requeue",
+            "type": "boolean",
+            "label": "Allow reviewing on requeues",
+            "defaultValue": false,
+            "helpMarkDown": "Set to true to allow revieiwing on requeues.  Default value is `false`."
         }
     ],
     "execution": {

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.17",
+    "version": "2.1.22",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
-Fixed issue where wrong diff would be generated causing PRIA to generate incorrect comments.
-Removed TargetBranch_IncludeOriginPrefix dev option as it's no longer needed since we're now diffing against merge-base. 
-Added Allow_Requeue option to allow PRIA to review on requeues.