### PR TITLE
developer role for message when o3 or o4-mini

### DIFF
--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -124,7 +124,12 @@ export class ChatGPT {
             let openAi = await this._client.chat.completions.create({
                 messages: [
                     {
-                        role: model == 'o1-preview' || model == 'o1-mini' ? 'assistant' : 'system',
+                        role:
+                            (model.includes('o3') || model.includes('o4'))
+                                ? 'developer'
+                                : (model === 'o1-preview' || model === 'o1-mini')
+                                    ? 'assistant'
+                                    : 'system',
                         content: this.systemMessage,
                     },
                     {


### PR DESCRIPTION
This adds support for the "thinking models" o3 and o4-mini.
The use a new "developer" role instead of the "system" role message