### PR TITLE
fix: fixed merge-base where it was failing on some repos

### DIFF
--- a/pr-inspection-assistant/src/main.ts
+++ b/pr-inspection-assistant/src/main.ts
@@ -77,10 +77,11 @@ export class Main {
             enableCommentLineCorrection,
             additionalPrompts
         );
-        this._repository = new Repository();
-        this._pullRequest = new PullRequest();
 
+        this._repository = await new Repository().init();
         await this._repository.setupCurrentBranch();
+
+        this._pullRequest = new PullRequest();
 
         const lastReviewedCommit = await this._pullRequest.getLastReviewedCommitHash();
         const lastMergedCommit = await this._pullRequest.getLastMergeSourceCommitHash();

--- a/pr-inspection-assistant/src/repository.ts
+++ b/pr-inspection-assistant/src/repository.ts
@@ -8,7 +8,7 @@ export class Repository {
     };
 
     private readonly _repository: SimpleGit;
-    private _mergeBase!: string;
+    private _mergeBase: string | undefined;
 
     constructor() {
         this._repository = simpleGit(this.gitOptions);
@@ -39,6 +39,10 @@ export class Repository {
     }
 
     public async getDiff(fileName: string): Promise<string> {
+        if (!this._mergeBase) {
+            throw new Error('Merge base is not set. Please initialize the repository first.');
+        }
+
         const args = [this._mergeBase, '--', fileName.replace(/^\//, '')];
         console.info('GetDiff()', args.join(' '));
         const diff = await this._repository.diff(args);

--- a/pr-inspection-assistant/src/repository.ts
+++ b/pr-inspection-assistant/src/repository.ts
@@ -8,11 +8,19 @@ export class Repository {
     };
 
     private readonly _repository: SimpleGit;
+    private _mergeBase!: string;
 
     constructor() {
         this._repository = simpleGit(this.gitOptions);
         this._repository.addConfig('core.pager', 'cat');
         this._repository.addConfig('core.quotepath', 'false');
+    }
+
+    public async init(): Promise<Repository> {
+        await this._repository.fetch();
+
+        this._mergeBase = await this.getMergeBase();
+        return this;
     }
 
     public async setupCurrentBranch(): Promise<void> {
@@ -31,21 +39,18 @@ export class Repository {
     }
 
     public async getDiff(fileName: string): Promise<string> {
-        const target = await this.getMergeBase();
-        const args = [target, '--', fileName.replace(/^\//, '')];
+        const args = [this._mergeBase, '--', fileName.replace(/^\//, '')];
         console.info('GetDiff()', args.join(' '));
         const diff = await this._repository.diff(args);
         return diff;
     }
 
     private async getMergeBase(): Promise<string> {
-        // In Azure DevOps, the source should always be HEAD as its current branch is based on a PR merge branch (eg., pull/xxxx/merge).
-        // Changing it to the PR source branch will cause merge-base to be different, which ultimately results in the diff to be incorrect.
-        // TODO: see if we can simplify this by leveraging ADO API to get the merge base or diff
-        const source = tl.isDev() ? this.getSourceBranch() : 'HEAD';
+        const source = this.getSourceBranch();
         const command = ['merge-base', this.getTargetBranch(), source];
+        console.info('GetMergeBase()', command.join(' '));
         const result = (await this._repository.raw(command)).trim();
-        console.info('GetMergeBase()', command.join(' '), `-> ${result}`);
+        console.info('GetMergeBase() result', result);
         return result;
     }
 

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 23
+        "Patch": 33
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.23",
+    "version": "2.1.33",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
this addresses an issue where, in some repos, retrieving the merge-base (used for diffing) yielded in an error.