### PR TITLE
fix: revert the merge-base impl as it results in possible incorrect file diff

### DIFF
--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 35
+        "Patch": 36
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.35",
+    "version": "2.1.36",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
The recent implementation of using merge-base to determine file diffs is problematic, as it results in a 2-way diff instead of a 3-way diff. As a result, whenever a file differs in the trunk (main/master), the generated diff may reference inaccurate code. Reverting to diffing against the trunk should resolve this issue, as it produces a 3-way diff. This is because the current branch references the branch to be merged, which contains the changes from the source branch.

Thinking back, I believe merge-base was introduced to address the issue of PRIA picking up and reviewing files outside of a PR. The original solution utilized merge-base to solve this problem but has since been replaced by the iteration-based implementation for determining the files for review.