### PR TITLE
fix: filter out null file paths in iteration changes

### DIFF
--- a/pr-inspection-assistant/src/pullRequest.ts
+++ b/pr-inspection-assistant/src/pullRequest.ts
@@ -63,7 +63,10 @@ export class PullRequest {
         const endpoint = `${this.getPullRequestBaseUri()}/iterations/${end}/changes?api-version=7.0&$compareTo=${start}`;
         const result = await this._ado.get<GitPullRequestIterationChanges>(endpoint);
 
-        const files = result.changeEntries.map(({ item }) => item.path);
+        const files = result.changeEntries
+            .map(({ item }) => item.path)
+            // filter out null paths.  this can happen if file has been deleted
+            .filter((file) => !!file);
         tl.debug(`Files in iteration ${start}-${end}: ${JSON.stringify(files)}`);
 
         return files;

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 36
+        "Patch": 37
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.36",
+    "version": "2.1.37",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
fixes the following error due to filepath possibly being null when gathering files from iteration:

##[error]Unhandled: Cannot read properties of null (reading 'slice')
##[error]TypeError: Cannot read properties of null (reading 'slice')
    at D:\a\_tasks\PRIA_d3b07384-d9a7-4f3b-8a1d-6e5f3d2b5c3a\2.1.36\fileUtils.js:11:95
    at Array.filter (<anonymous>)
    at filterFilesForReview (D:\a\_tasks\PRIA_d3b07384-d9a7-4f3b-8a1d-6e5f3d2b5c3a\2.1.36\fileUtils.js:11:31)
    at Function.filterFiles (D:\a\_tasks\PRIA_d3b07384-d9a7-4f3b-8a1d-6e5f3d2b5c3a\2.1.36\main.js:108:53)
    at Function.main (D:\a\_tasks\PRIA_d3b07384-d9a7-4f3b-8a1d-6e5f3d2b5c3a\2.1.36\main.js:33:36)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)