### PR TITLE
support node 20 to avoid deprecation warning

### DIFF
--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -148,6 +148,9 @@
         },
         "Node16": {
             "target": "main.js"
+        },
+        "Node20_1": {
+            "target": "main.js"
         }
     }
 }


### PR DESCRIPTION
Currently the review pipeline shows a warning about depending on end-of-life node version:

```
##[warning]Task 'PR Inspection Assistant' version 2 (PRIA@2) is dependent on a Node version (16) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
```