### PR TITLE
feat: add official support for o4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 -   A generated API key for you OpenAI service
 -   Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
 -   A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
-    -   By default the task will try to use a deployment called `'o3-mini'`
+    -   By default the task will try to use a deployment called `'o4-mini'`
     -   Valid options are:
+        -   'o4-mini'
         -   'o3-mini'
         -   'o1-mini'
         -   'o1-preview'
+        -   'o1'
         -   'gpt-4o'
         -   'gpt-4'
         -   'gpt-3.5-turbo'

--- a/pr-inspection-assistant/assets/overview.md
+++ b/pr-inspection-assistant/assets/overview.md
@@ -4,43 +4,46 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 
 ## Key Features
 
-- **Automated PR Reviews**: Leverage OpenAI to analyze code changes in pull requests.
-- **Supports Azure OpenAI**: Isolate your reviews using your own internal model deployments in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio).
-- **Code Quality Suggestions**: Detect potential issues and ensure best practices are followed.
-- **Customizable Review Criteria**: Tailor the bot to specific code quality metrics.
-- **Azure DevOps Integration**: Seamlessly integrates with existing DevOps pipelines.
-- **Natural Language Feedback**: Provides human-readable, actionable feedback.
+-   **Automated PR Reviews**: Leverage OpenAI to analyze code changes in pull requests.
+-   **Supports Azure OpenAI**: Isolate your reviews using your own internal model deployments in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio).
+-   **Code Quality Suggestions**: Detect potential issues and ensure best practices are followed.
+-   **Customizable Review Criteria**: Tailor the bot to specific code quality metrics.
+-   **Azure DevOps Integration**: Seamlessly integrates with existing DevOps pipelines.
+-   **Natural Language Feedback**: Provides human-readable, actionable feedback.
 
 ![AzureDevOps Comment](https://raw.githubusercontent.com/ewellnitz/pr-inspection-assistant/refs/heads/main/pr-inspection-assistant/assets/ado-ai-comment.jpg)
 
 ## Use Cases
 
-- **Automate Routine PR Tasks**: Speed up the code review process by automating common review tasks.
-- **Improve Code Quality**: Receive consistent, detailed feedback to enhance code quality.
-- **Early Bug Detection**: Help developers understand best practices and identify bugs early in the development cycle.
+-   **Automate Routine PR Tasks**: Speed up the code review process by automating common review tasks.
+-   **Improve Code Quality**: Receive consistent, detailed feedback to enhance code quality.
+-   **Early Bug Detection**: Help developers understand best practices and identify bugs early in the development cycle.
 
 ## Process
+
 ![Flowchart](https://raw.githubusercontent.com/ewellnitz/pr-inspection-assistant/refs/heads/main/pr-inspection-assistant/assets/flowchart.jpg)
 
 ## Prerequisites
 
-- An [OpenAI API Key](https://platform.openai.com/docs/overview)
-- Build Administrators must be given "Contribute to pull requests" access. Check [this Stack Overflow answer](https://stackoverflow.com/a/57985733) for guidance on setting up permissions.
+-   An [OpenAI API Key](https://platform.openai.com/docs/overview)
+-   Build Administrators must be given "Contribute to pull requests" access. Check [this Stack Overflow answer](https://stackoverflow.com/a/57985733) for guidance on setting up permissions.
 
 ### If Using Azure OpenAI
 
-- A generated API key for you OpenAI service
-- Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
-- A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
-  - By default the task will try to use a deployment called `'o3-mini'`
-  - Valid options are:
-    - 'o3-mini'
-    - 'o1-mini'
-    - 'o1-preview'
-    - 'gpt-4o'
-    - 'gpt-4'
-    - 'gpt-3.5-turbo'
-- A designated [API version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation). Defaults to `'2024-10-21'`
+-   A generated API key for you OpenAI service
+-   Your service endpoint URL e.g., `https://my-resource.azure.openai.com/`
+-   A [deployed model](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai)
+    -   By default the task will try to use a deployment called `'o4-mini'`
+    -   Valid options are:
+        -   'o4-mini'
+        -   'o3-mini'
+        -   'o1-mini'
+        -   'o1-preview'
+        -   'o1'
+        -   'gpt-4o'
+        -   'gpt-4'
+        -   'gpt-3.5-turbo'
+-   A designated [API version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation). Defaults to `'2024-10-21'`
 
 [Learn more about Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/azure-openai-in-ai-studio)
 
@@ -48,11 +51,11 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 
 ### 1. Install the PRIA DevOps Extension
 
-   Install the [PRIA](https://marketplace.visualstudio.com/items?itemName=EricWellnitz.pria) DevOps extension from the Azure DevOps Marketplace.
+Install the [PRIA](https://marketplace.visualstudio.com/items?itemName=EricWellnitz.pria) DevOps extension from the Azure DevOps Marketplace.
 
 ### 2. Create a PRIA Code Review Pipeline
 
-   Create an [Azure DevOps Pipeline](https://learn.microsoft.com/en-us/azure/devops/pipelines/create-first-pipeline) using the following YAML snippet to set up the PRIA code review task:
+Create an [Azure DevOps Pipeline](https://learn.microsoft.com/en-us/azure/devops/pipelines/create-first-pipeline) using the following YAML snippet to set up the PRIA code review task:
 
 #### OpenAI API
 
@@ -60,15 +63,15 @@ Automate pull request (PR) reviews in Azure DevOps using the PR Inspection Assis
 trigger: none
 
 jobs:
-  - job: CodeReview
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-        persistCredentials: true
-      - task: PRIA@2
-        inputs:
-          api_key: '$(OpenAI_ApiKey)'
+    - job: CodeReview
+      pool:
+          vmImage: 'ubuntu-latest'
+      steps:
+          - checkout: self
+            persistCredentials: true
+          - task: PRIA@2
+            inputs:
+                api_key: '$(OpenAI_ApiKey)'
 ```
 
 #### Azure OpenAI
@@ -77,39 +80,39 @@ jobs:
 trigger: none
 
 jobs:
-  - job: CodeReview
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-        persistCredentials: true
-      - task: PRIA@2
-        inputs:
-          api_key: '$(OpenAI_ApiKey)'
-          api_version: '2024-10-21'
-          api_endpoint: 'https://my-foundry-project.openai.azure.com/'
-          ai_model: 'gpt-4o'
+    - job: CodeReview
+      pool:
+          vmImage: 'ubuntu-latest'
+      steps:
+          - checkout: self
+            persistCredentials: true
+          - task: PRIA@2
+            inputs:
+                api_key: '$(OpenAI_ApiKey)'
+                api_version: '2024-10-21'
+                api_endpoint: 'https://my-foundry-project.openai.azure.com/'
+                ai_model: 'gpt-4o'
 ```
+
 ### 3. Optional Task Inputs
 
 Additional input options can be set to tailor how the code is reviewed.
 
-| Input | Type | Default | Description |
-|---|---|---|---|
-| `bugs` | Boolean | `false` | Specify whether to enable bug checking during the code review process. |
-| `performance` | Boolean | `false` | Specify whether to include performance checks during the code review process. |
-| `best_practices` | Boolean | `false` | Specify whether to include checks for missed best practices during the code review process. |
-| `modified_lines_only` | Boolean | `true` | Specify whether to check modified lines only. |
-| `file_extensions` | String | `null` | Specify a comma-separated list of file extensions for which you want to perform a code review. |
-| `file_excludes` | String | `null` | Specify a comma-separated list of file names that should be excluded from code reviews. |
-| `additional_prompts` | String | `null` | Specify additional OpenAI prompts as a comma-separated list to enhance the code review. |
+| Input                 | Type    | Default | Description                                                                                    |
+| --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `bugs`                | Boolean | `false` | Specify whether to enable bug checking during the code review process.                         |
+| `performance`         | Boolean | `false` | Specify whether to include performance checks during the code review process.                  |
+| `best_practices`      | Boolean | `false` | Specify whether to include checks for missed best practices during the code review process.    |
+| `modified_lines_only` | Boolean | `true`  | Specify whether to check modified lines only.                                                  |
+| `file_extensions`     | String  | `null`  | Specify a comma-separated list of file extensions for which you want to perform a code review. |
+| `file_excludes`       | String  | `null`  | Specify a comma-separated list of file names that should be excluded from code reviews.        |
+| `additional_prompts`  | String  | `null`  | Specify additional OpenAI prompts as a comma-separated list to enhance the code review.        |
 
 ### 4. Configure your Main Branch for Build Validation
 
-  Note that `pr` triggers do not work in Azure repos.
-  
-  Cofigure Azure DevOps [branch policies](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation) to use the PRIA Code Review Pipeline created above as a build validation pipeline.
+Note that `pr` triggers do not work in Azure repos.
 
+Cofigure Azure DevOps [branch policies](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation) to use the PRIA Code Review Pipeline created above as a build validation pipeline.
 
 ## Build & Publish
 
@@ -127,5 +130,6 @@ $ npm run package
 ```
 
 ### Resources
-- [Marketplace Pipeline Extension](https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops)
-- [Publisher Portal](https://marketplace.visualstudio.com/manage/publishers)
+
+-   [Marketplace Pipeline Extension](https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops)
+-   [Publisher Portal](https://marketplace.visualstudio.com/manage/publishers)

--- a/pr-inspection-assistant/src/.env.local.example
+++ b/pr-inspection-assistant/src/.env.local.example
@@ -6,7 +6,7 @@ Build_Reason=PullRequest
 # OpenAI API Key
 Api_Key=<your_api_key>
 # OpenAI Model to use for code review
-Ai_Model=o3-mini
+Ai_Model=o4-mini
 
 # Azure DevOps Bearer Token.  Used to authenticate to Azure DevOps API
 System_AccessToken=<your_access_token>

--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -115,9 +115,11 @@ export class ChatGPT {
         }
         let model = tl.getInput('ai_model', true) as
             | (string & {})
+            | 'o4-mini'
             | 'o3-mini'
             | 'o1-mini'
             | 'o1-preview'
+            | 'o1'
             | 'gpt-4o'
             | 'gpt-4'
             | 'gpt-3.5-turbo';
@@ -136,11 +138,11 @@ export class ChatGPT {
                 messages: [
                     {
                         role:
-                            (model.includes('o3') || model.includes('o4'))
+                            model.includes('o3') || model.includes('o4')
                                 ? 'developer'
-                                : (model === 'o1-preview' || model === 'o1-mini')
-                                    ? 'assistant'
-                                    : 'system',
+                                : model === 'o1-preview' || model === 'o1-mini'
+                                ? 'assistant'
+                                : 'system',
                         content: this.systemMessage,
                     },
                     {

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 42
+        "Patch": 44
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [
@@ -41,11 +41,13 @@
             "name": "ai_model",
             "type": "pickList",
             "label": "OpenAI API Model",
-            "defaultValue": "o3-mini",
+            "defaultValue": "o4-mini",
             "options": {
+                "o4-mini": "o4-mini",
                 "o3-mini": "o3-mini",
                 "o1-mini": "o1-mini",
                 "o1-preview": "o1-preview",
+                "o1": "o1",
                 "gpt-4o": "gpt-4o",
                 "gpt-4": "gpt-4",
                 "gpt-3.5-turbo": "gpt-3.5-turbo"

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.42",
+    "version": "2.1.44",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
This PR adds official support for the OpenAI o4-mini model to the PR Inspection Assistant extension. The change updates the default model from o3-mini to o4-mini and adds o4-mini and o1 as available model options.

Key changes:
- Updated default AI model from o3-mini to o4-mini across configuration files
- Added o4-mini and o1 model options to the available model list