### PR TITLE
feat: add deduplication options for comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,7 +244,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
-.env.local
+.env.local*
 .taskkey
 
 # Sourcemap

--- a/pr-inspection-assistant/src/.env.local.example
+++ b/pr-inspection-assistant/src/.env.local.example
@@ -44,6 +44,10 @@ Modified_Lines_Only=true
 Confidence_Mode=false
 # Set the minimum confidence score (1-10) required for comments to appear. Only comments with a confidence score equal to or above this value will be shown.
 Confidence_Minimum=9
+# Set to true to enable deduplication of comments across files
+Dedupe_Across_Files=false
+# Set the threshold of the total PR comments before deduplication is applied.
+Dedupe_Across_Files_Threshold=10
 
 
 #--- Development Options ---

--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -64,7 +64,7 @@ export class ChatGPT {
                     ],
                     "status": 1,
                     "threadContext": {
-                        "filePath": "<string: path to file.  use filePath that was provided.>",
+                        "filePath": "<string: path to file. use filePath that was provided.>",
                         //only include leftFile properties for suggestions on unmodified lines
                         "leftFileStart": {
                             "line": <integer: line where the suggestion starts>,

--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -4,6 +4,7 @@ import { OpenAI, AzureOpenAI } from 'openai';
 import parseGitDiff, { AddedLine, AnyChunk, AnyLineChange, DeletedLine, GitDiff, UnchangedLine } from 'parse-git-diff';
 import { CommentLineNumberAndOffsetFixer } from './commentLineNumberAndOffsetFixer';
 import { Review } from './types/review';
+import { Logger } from './logger';
 
 type Client = OpenAI | AzureOpenAI;
 
@@ -29,7 +30,7 @@ export class ChatGPT {
         this.systemMessage = `Your task is to act as a code reviewer of a pull request within Azure DevOps.
         - You are provided with the code changes (diff) in a Unified Diff format.
         - You are provided with a file path (fileName).
-        - You are provided with existing comments (existingComments) on the file, you must provide any additional code review comments that are not duplicates.
+        - You are provided with a string array of existing comments (existingComments). Only add new comments for issues not already in existingComments.  For each distinct issue, leave a single comment and instruct the author to apply it to all affected areas in the pull request.
         - Do not highlight minor issues and nitpicks.
         ${
             enableConfidenceMode
@@ -63,7 +64,7 @@ export class ChatGPT {
                     ],
                     "status": 1,
                     "threadContext": {
-                        "filePath": "<string: path to file>",
+                        "filePath": "<string: path to file.  use filePath that was provided.>",
                         //only include leftFile properties for suggestions on unmodified lines
                         "leftFileStart": {
                             "line": <integer: line where the suggestion starts>,
@@ -77,22 +78,14 @@ export class ChatGPT {
                         //only use rightFile properties if the line changed in the diff
                         "rightFileStart": {
                             "line": <integer: line where the suggestion starts>,
-                            "snippet": "<code snippet for suggestion>",
-                            "offset": <integer: character offset where the suggestion starts>
+                            "offset": <integer: character offset where the suggestion starts>,
+                            "snippet": "<code snippet for suggestion>"
                         },
                         "rightFileEnd": {
                             "line": <integer: line where the suggestion ends>,
                             "offset": <integer: character offset where the suggestion ends>
                         }
-                    },
-                    // Commenting out these for now as they're not working correctly and causes comments to be added to wrong files
-                    // "pullRequestThreadContext": {
-                    //     "changeTrackingId": <integer>, //Used to track a comment across iterations. Can be found by looking at the iteration changes list
-                    //     "iterationContext": {
-                    //         "firstComparingIteration": <integer>, //iteration of the file on the left side of the diff when the thread was created
-                    //         "secondComparingIteration": <integer> //iteration of the file on the right side of the diff when the thread was created
-                    //     }
-                    // }
+                    }
                 }
             ]
         }`;
@@ -131,8 +124,9 @@ export class ChatGPT {
         };
 
         let prompt = JSON.stringify(userPrompt, null, 4);
-        console.info(`Diff:\n${diff}`);
-        // console.info(`Prompt:\n${prompt}`);
+
+        Logger.info(`Diff:\n${diff}`);
+
         if (!this.doesMessageExceedTokenLimit(this.systemMessage + prompt, this.maxTokens)) {
             let openAi = await this._client.chat.completions.create({
                 messages: [
@@ -157,11 +151,11 @@ export class ChatGPT {
 
             if (response.length > 0) {
                 let content = response[0].message.content!;
-                console.info(`Comments:\n${content}`);
+                Logger.info(`Comments:\n${content}`);
                 try {
                     return JSON.parse(content);
                 } catch (error) {
-                    console.error(
+                    Logger.error(
                         `Failed to parse review response for file ${fileName}.  Returning empty review`,
                         error
                     );

--- a/pr-inspection-assistant/src/chatGpt.ts
+++ b/pr-inspection-assistant/src/chatGpt.ts
@@ -30,7 +30,7 @@ export class ChatGPT {
         this.systemMessage = `Your task is to act as a code reviewer of a pull request within Azure DevOps.
         - You are provided with the code changes (diff) in a Unified Diff format.
         - You are provided with a file path (fileName).
-        - You are provided with a string array of existing comments (existingComments). Only add new comments for issues not already in existingComments.  For each distinct issue, leave a single comment and instruct the author to apply it to all affected areas in the pull request.
+        - You are provided with a string array of existing comments (existingComments). Only add new comments for issues not already in existingComments. For each distinct issue, leave a single comment and instruct the author to apply it to all affected areas in the pull request.
         - Do not highlight minor issues and nitpicks.
         ${
             enableConfidenceMode

--- a/pr-inspection-assistant/src/commentUtils.dedupe.test.ts
+++ b/pr-inspection-assistant/src/commentUtils.dedupe.test.ts
@@ -1,0 +1,96 @@
+import { CommentUtils } from './commentUtils';
+import { InputValues } from './types/inputValues';
+import { Comment } from './types/comment';
+
+describe('CommentUtils.getCommentContentForExclusion', () => {
+    const fileComments: Comment[] = [
+        { content: 'A', confidenceScore: 0.9, commentType: 0 },
+        { content: 'B', confidenceScore: 0.5, commentType: 0 },
+    ];
+    const runComments: Comment[] = [
+        { content: 'C', confidenceScore: 0.7, commentType: 0 },
+        { content: 'D', confidenceScore: 0.3, commentType: 0 },
+    ];
+    const baseInputs = {
+        confidenceMode: true,
+        confidenceMinimum: 0.6,
+        dedupeAcrossFiles: true,
+        dedupeAcrossFilesThreshold: 1,
+    } as InputValues;
+
+    it('returns only file comments if deduplication threshold is not met', () => {
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            runComments.slice(0, 1), // Only 1 run comment, threshold is 1
+            baseInputs,
+            false
+        );
+        expect(excluded).toEqual(['A', 'B']);
+        expect(dedupeMet).toBe(false);
+    });
+
+    it('returns only file comments if not enough run comments pass confidence to exceed threshold', () => {
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            runComments, // Only 1 run comment passes confidence, threshold is 1
+            baseInputs,
+            false
+        );
+        expect(excluded).toEqual(['A', 'B']);
+        expect(dedupeMet).toBe(false);
+    });
+
+    it('returns file and run comments and sets deduplication flag to true when threshold is exceeded (all run comments pass confidence)', () => {
+        const passingRunComments: Comment[] = [
+            { content: 'C', confidenceScore: 0.7, commentType: 0 },
+            { content: 'D', confidenceScore: 0.8, commentType: 0 },
+        ];
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            passingRunComments, // 2 run comments pass confidence, threshold is 1
+            baseInputs,
+            false
+        );
+        expect(excluded).toEqual(['A', 'B', 'C', 'D']);
+        expect(dedupeMet).toBe(true);
+    });
+
+    it('returns file and run comments if deduplication already met', () => {
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            runComments,
+            baseInputs,
+            true // Deduplication already met
+        );
+        expect(excluded).toEqual(['A', 'B', 'C', 'D']);
+        expect(dedupeMet).toBe(true);
+    });
+
+    it('returns only file comments if dedupeAcrossFiles mode is off', () => {
+        const inputs = { ...baseInputs, dedupeAcrossFiles: false };
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            runComments,
+            inputs,
+            false
+        );
+        expect(excluded).toEqual(['A', 'B']);
+        expect(dedupeMet).toBe(false);
+    });
+
+    it('returns file and run comments if deduplication threshold is exceeded and confidenceMode is false', () => {
+        const inputs = {
+            ...baseInputs,
+            confidenceMode: false,
+        };
+        // All run comments are counted, so 2 > 1 triggers deduplication
+        const [excluded, dedupeMet] = CommentUtils.getCommentContentForExclusion(
+            fileComments,
+            runComments,
+            inputs,
+            false
+        );
+        expect(excluded).toEqual(['A', 'B', 'C', 'D']);
+        expect(dedupeMet).toBe(true);
+    });
+});

--- a/pr-inspection-assistant/src/commentUtils.test.ts
+++ b/pr-inspection-assistant/src/commentUtils.test.ts
@@ -1,0 +1,49 @@
+import { CommentUtils } from './commentUtils';
+import { InputValues } from './types/inputValues';
+import { Comment } from './types/comment';
+
+describe('CommentUtils', () => {
+    const baseComments: Comment[] = [
+        { content: 'A', confidenceScore: 0.9, commentType: 0 },
+        { content: 'B', confidenceScore: 0.5, commentType: 0 },
+        { content: 'C', confidenceScore: 0.2, commentType: 0 },
+        { content: 'D', commentType: 0 }, // No confidenceScore
+    ];
+
+    describe('filterCommentsByConfidence', () => {
+        it('filters out comments below the minimum confidence', () => {
+            const { filteredOut, remaining } = CommentUtils.filterCommentsByConfidence(baseComments, 0.6);
+            expect(filteredOut.map((c) => c.content)).toEqual(['B', 'C']);
+            expect(remaining.map((c) => c.content)).toEqual(['A', 'D']);
+        });
+        it('returns all comments as remaining if all meet threshold', () => {
+            const { filteredOut, remaining } = CommentUtils.filterCommentsByConfidence(baseComments, 0.1);
+            expect(filteredOut).toEqual([]);
+            expect(remaining.length).toBe(4);
+        });
+        it('returns all comments as filteredOut if all below threshold', () => {
+            const { filteredOut, remaining } = CommentUtils.filterCommentsByConfidence(baseComments, 1.0);
+            expect(filteredOut.length).toBe(3); // D has no score, so remains
+            expect(remaining.map((c) => c.content)).toEqual(['D']);
+        });
+    });
+
+    describe('filterCommentsByInputs', () => {
+        const baseInputs = {
+            confidenceMode: true,
+            confidenceMinimum: 0.6,
+        } as InputValues;
+
+        it('filters using confidenceMode and confidenceMinimum', () => {
+            const { filteredOut, remaining } = CommentUtils.filterCommentsByInputs(baseComments, baseInputs);
+            expect(filteredOut.map((c) => c.content)).toEqual(['B', 'C']);
+            expect(remaining.map((c) => c.content)).toEqual(['A', 'D']);
+        });
+        it('returns all as remaining if confidenceMode is false', () => {
+            const inputs = { ...baseInputs, confidenceMode: false };
+            const { filteredOut, remaining } = CommentUtils.filterCommentsByInputs(baseComments, inputs);
+            expect(filteredOut).toEqual([]);
+            expect(remaining.length).toBe(4);
+        });
+    });
+});

--- a/pr-inspection-assistant/src/commentUtils.ts
+++ b/pr-inspection-assistant/src/commentUtils.ts
@@ -1,0 +1,72 @@
+import { InputValues } from './types/inputValues';
+import { Comment } from './types/comment';
+import { Logger } from './logger';
+
+/**
+ * Utilities for filtering and processing comments.
+ */
+export class CommentUtils {
+    /**
+     * Filter comments by confidence mode and minimum confidence.
+     */
+    static filterCommentsByInputs(comments: Comment[], inputs: InputValues) {
+        if (inputs.confidenceMode) {
+            const { filteredOut, remaining } = this.filterCommentsByConfidence(comments, inputs.confidenceMinimum);
+            return { filteredOut, remaining };
+        }
+        return { filteredOut: [], remaining: comments };
+    }
+
+    /**
+     * Filter comments by confidence score.
+     */
+    static filterCommentsByConfidence(comments: Comment[], confidenceMinimum: number) {
+        const filteredOut: Comment[] = [];
+        const remaining: Comment[] = [];
+        comments.forEach((comment) => {
+            if (comment.confidenceScore !== undefined && comment.confidenceScore < confidenceMinimum) {
+                filteredOut.push(comment);
+            } else {
+                remaining.push(comment);
+            }
+        });
+        return { filteredOut, remaining };
+    }
+
+    /**
+     * Determines which comment contents should be excluded based on deduplication logic.
+     * File comments are always excluded. Run comments are excluded if deduplication criteria are met (based on flag and threshold).
+     *
+     * @param fileComments - Comments already present in the file.
+     * @param runComments - Comments generated in the current review run.
+     * @param inputs - Input values controlling deduplication and filtering.
+     * @param deduplicationCriteriaMet - Whether deduplication criteria has already been met.
+     * @returns A tuple: [array of comment contents to exclude, updated deduplication criteria state].
+     */
+    static getCommentContentForExclusion(
+        fileComments: Comment[],
+        runComments: Comment[],
+        inputs: InputValues,
+        deduplicationCriteriaMet: boolean
+    ): [string[], boolean] {
+        let commentsForExclusion = [...fileComments];
+        let dedupeMet = deduplicationCriteriaMet;
+        if (inputs.dedupeAcrossFiles) {
+            if (!dedupeMet) {
+                const currentRunCommentCount = this.filterCommentsByInputs(runComments, inputs).remaining.length;
+                Logger.info(`Current run comment count: ${currentRunCommentCount}`);
+
+                if (currentRunCommentCount > inputs.dedupeAcrossFilesThreshold) {
+                    dedupeMet = true;
+                    Logger.info('Deduplicate comments across files criteria met.');
+                } else {
+                    Logger.info('Deduplicate comments across files criteria has NOT been met.');
+                }
+            }
+            if (dedupeMet) {
+                commentsForExclusion = [...fileComments, ...runComments];
+            }
+        }
+        return [commentsForExclusion.map((comment) => comment.content), dedupeMet];
+    }
+}

--- a/pr-inspection-assistant/src/inputManager.ts
+++ b/pr-inspection-assistant/src/inputManager.ts
@@ -1,0 +1,49 @@
+import tl from './taskWrapper';
+import { InputValues } from './types/inputValues';
+import { Logger } from './logger';
+
+export class InputManager {
+    public static logInputs(inputs: any): void {
+        for (const [key, value] of Object.entries(inputs)) {
+            if (key === 'apiKey') {
+                Logger.info(`${key}: ***`); // Mask sensitive fields
+            } else {
+                Logger.info(`${key}: ${value}`);
+            }
+        }
+    }
+    private static _inputs: InputValues;
+
+    public static get inputs(): InputValues {
+        if (!this._inputs) {
+            this._inputs = this.loadInputs();
+        }
+        return this._inputs;
+    }
+
+    private static loadInputs(): InputValues {
+        const inputs = {
+            apiKey: tl.getInput('api_key', true)!,
+            azureApiEndpoint: tl.getInput('api_endpoint', false)!,
+            azureApiVersion: tl.getInput('api_version', false)!,
+            azureModelDeployment: tl.getInput('ai_model', false)!,
+            fileExtensions: tl.getInput('file_extensions', false),
+            fileExtensionExcludes: tl.getInput('file_extension_excludes', false),
+            filesToInclude: tl.getInput('file_includes', false),
+            filesToExclude: tl.getInput('file_excludes', false),
+            additionalPrompts: tl.getInput('additional_prompts', false)?.split(','),
+            bugs: tl.getBoolInput('bugs', false),
+            performance: tl.getBoolInput('performance', false),
+            bestPractices: tl.getBoolInput('best_practices', false),
+            modifiedLinesOnly: tl.getBoolInput('modified_lines_only', false),
+            enableCommentLineCorrection: tl.getBoolInput('comment_line_correction', false),
+            allowRequeue: tl.getBoolInput('allow_requeue', false),
+            confidenceMode: tl.getBoolInput('confidence_mode', false),
+            confidenceMinimum: parseInt(tl.getInput('confidence_minimum', false) ?? '9', 10),
+            dedupeAcrossFiles: tl.getBoolInput('dedupe_across_files', false),
+            dedupeAcrossFilesThreshold: parseInt(tl.getInput('dedupe_across_files_threshold', false) ?? '10', 10),
+        };
+        this.logInputs(inputs);
+        return inputs;
+    }
+}

--- a/pr-inspection-assistant/src/logger.ts
+++ b/pr-inspection-assistant/src/logger.ts
@@ -10,26 +10,33 @@ export class Logger {
     }
 
     public static info(message: string, ...args: any[]): void {
-        console.info(message, ...args);
+        // Info logs are always shown in Azure DevOps
+        console.log(message, ...args);
         this.flushLogs();
     }
 
     public static error(message: string, ...args: any[]): void {
-        console.error(message, ...args);
+        // Azure DevOps error log command
+        console.log(`##vso[task.logissue type=error]${message}`, ...args);
         this.flushLogs();
     }
 
     public static warn(message: string, ...args: any[]): void {
-        console.warn(message, ...args);
+        // Azure DevOps warning log command
+        console.log(`##vso[task.logissue type=warning]${message}`, ...args);
         this.flushLogs();
     }
 
     public static debug(message: string, ...args: any[]): void {
-        console.debug(message, ...args);
-        this.flushLogs();
+        // Only log debug if system.debug is true in Azure DevOps
+        if (process.env['SYSTEM_DEBUG'] === 'true' || process.env['system.debug'] === 'true') {
+            console.log(`##vso[task.debug]${message}`, ...args);
+            this.flushLogs();
+        }
     }
 
     public static log(message: string, ...args: any[]): void {
+        // Generic log, always shown
         console.log(message, ...args);
         this.flushLogs();
     }

--- a/pr-inspection-assistant/src/main.ts
+++ b/pr-inspection-assistant/src/main.ts
@@ -16,7 +16,7 @@ export class Main {
     private static _chatGpt: ChatGPT;
     private static _repository: Repository;
     private static _pullRequest: PullRequest;
-    private static deduplicationCriteriaMet: boolean;
+    private static deduplicationCriteriaMet: boolean = false;
 
     public static async main(): Promise<void> {
         if (!this.isValidTrigger()) return;
@@ -39,7 +39,7 @@ export class Main {
         }
 
         const iterationFiles = await this._pullRequest.getIterationFiles(reviewRange);
-        Logger.info(`Found ${iterationFiles.length} changed files in this run:`, iterationFiles);
+        Logger.info(`Found ${iterationFiles.length} changed files in this run:`);
 
         const filesToReview = this.filterFiles(iterationFiles, inputs);
         Logger.info(`After filtering, ${filesToReview.length} files will be reviewed:`, filesToReview);
@@ -144,7 +144,7 @@ export class Main {
                 inputs
             );
 
-            Logger.info('File comments: ' + existingFileComments.length);
+            Logger.info('Existing file comments: ' + existingFileComments.length);
             Logger.info('Current run comments: ' + currentRunComments.length);
             Logger.info('Comments for exclusion: ' + commentsForExclusion.length, commentsForExclusion);
 

--- a/pr-inspection-assistant/src/pullRequest.ts
+++ b/pr-inspection-assistant/src/pullRequest.ts
@@ -7,6 +7,7 @@ import { PropertiesCollection } from './types/azureDevOps/propertiesCollection';
 import { GitPullRequestIterationChanges } from './types/azureDevOps/gitPullRequestIterationChanges';
 import { IterationRange } from './types/iterationRange';
 import { Thread } from './types/thread';
+import { Comment } from './types/comment';
 
 export class PullRequest {
     private _httpsAgent: Agent;
@@ -201,7 +202,7 @@ export class PullRequest {
         return comments;
     }
 
-    public async getCommentsForFile(fileName: string): Promise<string[]> {
+    public async getCommentsForFile(fileName: string): Promise<Comment[]> {
         if (!fileName.startsWith('/')) {
             fileName = `/${fileName}`;
         }
@@ -209,7 +210,7 @@ export class PullRequest {
         let buildServiceName = `${tl.getVariable('SYSTEM.TEAMPROJECT')} Build Service (${collectionName})`;
 
         const threads = await this.getThreads();
-        const comments: string[] = [];
+        const comments: Comment[] = [];
 
         Logger.info(`fileName: ${fileName}`);
         Logger.info(`collectionName: ${collectionName}`);
@@ -224,7 +225,7 @@ export class PullRequest {
                 //TODO: this filter is not working in all envrionments
                 //for (let comment of threadComments.value.filter((comment: any) => comment.author.displayName === buildServiceName) as any[]) {
                 for (let comment of threadComments.value as any[]) {
-                    comments.push(comment.content);
+                    comments.push(comment);
                 }
             }
         }

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -156,6 +156,20 @@
             "label": "Minimum confidence score (Experimental)",
             "defaultValue": "9",
             "helpMarkDown": "Set the minimum confidence score (1-10) required for comments to appear. Only comments with a confidence score equal to or above this value will be shown."
+        },
+        {
+            "name": "dedupe_across_files",
+            "type": "boolean",
+            "label": "Enable deduplication of comments across files",
+            "defaultValue": false,
+            "helpMarkDown": "Set to true to prevent the same comment from appearing multiple times across different files in the code review. Use in combination with `dedupe_across_files_threshold`."
+        },
+        {
+            "name": "dedupe_across_files_threshold",
+            "type": "string",
+            "label": "Deduplication of comments across files threshold",
+            "defaultValue": "10",
+            "helpMarkDown": "Set the threshold of the total PR comments before deduplication is applied."
         }
     ],
     "execution": {

--- a/pr-inspection-assistant/src/task.json
+++ b/pr-inspection-assistant/src/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 44
+        "Patch": 45
     },
     "instanceNameFormat": "PRIA $(message)",
     "inputs": [

--- a/pr-inspection-assistant/src/types/inputValues.ts
+++ b/pr-inspection-assistant/src/types/inputValues.ts
@@ -16,4 +16,6 @@ export interface InputValues {
     allowRequeue: boolean;
     confidenceMode: boolean;
     confidenceMinimum: number;
+    dedupeAcrossFiles: boolean;
+    dedupeAcrossFilesThreshold: number;
 }

--- a/pr-inspection-assistant/vss-extension.json
+++ b/pr-inspection-assistant/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "pria",
-    "version": "2.1.44",
+    "version": "2.1.45",
     "name": "PR Inspection Assistant",
     "publisher": "EricWellnitz",
     "public": true,


### PR DESCRIPTION
- feat: add deduplication options for comments across files: 
  - `dedupe_across_files` - enable comment deduplication across file
  - `dedupe_across_files_threshold` - threshold before deduplication takes effect
- feat: combine duplicate comments within a file into a single comment
- chore: enhance input management
- fix: sporadic missing leading slash (/) in filenames from LLM, which caused comments to show "This file no longer exists in the latest pull request changes..."